### PR TITLE
Agregando persistencia del theme

### DIFF
--- a/src/js/hydra.js
+++ b/src/js/hydra.js
@@ -1,4 +1,8 @@
 $(document).ready(function(){
+  // Se lee el theme de LocalStorage y se agrega la clase css a la etiqueta html
+  current_theme = localStorage.getItem("theme") ? localStorage.getItem("theme") : "theme-light";
+  $('html').addClass(current_theme);
+  
   $('.modal-open').on('click', function(ev){
     ev.preventDefault();
     modalId = $(this).data('modal-id');
@@ -34,7 +38,9 @@ $(document).ready(function(){
 
     current_theme = $('html').hasClass('theme-dark') ? 'theme-dark' : 'theme-light';
     new_theme = current_theme == 'theme-dark' ? 'theme-light' : 'theme-dark'
-
+    
+    // Se guarda el theme en LocalStorage después de cada cambio
+    localStorage.setItem('theme', new_theme);
     $('html').removeClass(current_theme).addClass(new_theme);
   });
 });


### PR DESCRIPTION
Se guarda en LocalStorage el theme actual, ya sea dark o light para que el usuario no tenga que cambiarlo en cada página